### PR TITLE
Refactor: Revise codebase for language, robustness, and dependencies.

### DIFF
--- a/components/get_data/run.py
+++ b/components/get_data/run.py
@@ -10,31 +10,42 @@ from wandb_utils.log_artifact import log_artifact
 logging.basicConfig(level=logging.INFO, format="%(asctime)-15s %(message)s")
 logger = logging.getLogger(__name__)
 
-print("sys.argv:", sys.argv)
+print("Argumentos do sistema:", sys.argv)
 def go(args):
-    os.makedirs("data", exist_ok=True)
+    # Usa o diretório de dados local fornecido por argumento
+    logger.info(f"Usando diretório de dados local: {args.local_data_dir}")
+    os.makedirs(args.local_data_dir, exist_ok=True)
+    
     project = os.environ.get("WANDB_PROJECT")
+    # Mantido artifact_full_name por clareza, já que é um nome composto
     artifact_full_name = args.artifact_name
 
     if project and artifact_exists(project, artifact_full_name):
-        logger.info(f"Artifact '{artifact_full_name}' encontrado no W&B. Baixando direto do W&B.")
+        logger.info(f"Artefato '{artifact_full_name}' encontrado no W&B. Baixando diretamente do W&B.")
         run = wandb.init(project=project, job_type="download_file")
         artifact = run.use_artifact(artifact_full_name)
-        artifact_dir = artifact.download("data")
-        logger.info(f"Arquivo {artifact_full_name} baixado para data")
+        # Baixa para o diretório de dados local configurado
+        artifact_dir = artifact.download(args.local_data_dir)
+        logger.info(f"Arquivo {artifact_full_name} baixado para a pasta '{args.local_data_dir}'")
         csv_files = [os.path.join(artifact_dir, f) for f in os.listdir(artifact_dir) if f.endswith(".csv")]
         if not csv_files:
-            logger.error("Nenhum arquivo CSV encontrado no artifact do W&B.")
+            logger.error("Nenhum arquivo CSV encontrado no artefato do W&B.")
             return
-        file_to_log = csv_files[0]
+        file_to_log = csv_files[0] # Mantido file_to_log por clareza
         run.finish()
     else:
-        logger.info(f"Artifact '{artifact_full_name}' não encontrado no W&B. Baixando do link fornecido.")
-        output_path = os.path.join("data", os.path.basename(args.sample))
-        download_file(args.sample, output_path)
+        logger.info(f"Artefato '{artifact_full_name}' não encontrado no W&B. Baixando do link fornecido.")
+        # Usa o diretório de dados local para o caminho de saída
+        output_path = os.path.join(args.local_data_dir, os.path.basename(args.sample))
+        download_successful = download_file(args.sample, output_path)
+
+        if not download_successful:
+            logger.error(f"Falha ao baixar o arquivo de {args.sample}. Verifique a URL e a conexão de rede. Interrompendo o processo.")
+            return
 
         if output_path.endswith(".zip"):
-            csv_files = extract_csv_from_zip(output_path, extract_dir="data")
+            # Extrai para o diretório de dados local configurado
+            csv_files = extract_csv_from_zip(output_path, extract_dir=args.local_data_dir, delete_zip_after_extraction=True)
             if not csv_files:
                 logger.error("Nenhum arquivo CSV encontrado para enviar ao W&B.")
                 return
@@ -42,11 +53,11 @@ def go(args):
         elif output_path.endswith(".csv"):
             file_to_log = output_path
         else:
-            logger.error("Arquivo baixado não é .zip nem .csv. Nada será enviado ao W&B.")
+            logger.error("O arquivo baixado não é .zip nem .csv. Nada será enviado ao W&B.")
             return
 
         run = wandb.init(job_type="download_file")
-        run.config.update(vars(args))
+        run.config.update(vars(args)) # vars(args) é idiomático, mantido
 
         logger.info(f"Enviando {args.artifact_name} para o Weights & Biases")
         log_artifact(
@@ -60,11 +71,19 @@ def go(args):
 
 if __name__ == "__main__":
     import argparse
-    parser = argparse.ArgumentParser(description="Download URL to a local destination e envia o CSV para o W&B")
-    parser.add_argument("--sample", type=str, help="URL da base para download")
-    parser.add_argument("--artifact_name", type=str, help="Nome do artefato no wandb (padrão: teste)")
-    parser.add_argument("--artifact_type", type=str, help="Tipo do artefato (padrão: teste)")
-    parser.add_argument("--artifact_description", type=str, help="Descrição do artefato (padrão: teste)")
-    args = parser.parse_args()
-    print("ARGS:", args)
+    # Mantido parser por ser convenção
+    parser = argparse.ArgumentParser(description="Baixa uma URL para um destino local e envia o CSV para o W&B")
+    parser.add_argument("--sample", type=str, help="URL da amostra para baixar")
+    parser.add_argument("--artifact_name", type=str, help="Nome do artefato no W&B (padrão: nome do arquivo baixado)")
+    parser.add_argument("--artifact_type", type=str, help="Tipo do artefato (padrão: raw_data)")
+    parser.add_argument("--artifact_description", type=str, help="Descrição do artefato (padrão: Dados brutos)")
+    # Novo argumento para o diretório de dados local
+    parser.add_argument(
+        "--local_data_dir", 
+        type=str, 
+        default="data", 
+        help="Diretório local para baixar e extrair arquivos (padrão: data)"
+    )
+    args = parser.parse_args() # Mantido args por ser convenção
+    print("Argumentos:", args)
     go(args)

--- a/components/get_data/wandb_utils/log_artifact.py
+++ b/components/get_data/wandb_utils/log_artifact.py
@@ -5,34 +5,34 @@ import logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)-15s %(message)s")
 logger = logging.getLogger(__name__)
 
-def log_artifact(artifact_name, artifact_type, artifact_description, filename, wandb_run):
+def log_artifact(nome_artefato, tipo_artefato, descricao_artefato, nome_arquivo, execucao_wandb):
     """
-    Log an artifact to Weights & Biases.
+    Registra um artefato no Weights & Biases.
 
-    Parameters
+    Parâmetros
     ----------
-    artifact_name : str
-        The name of the artifact.
-    artifact_type : str
-        The type of the artifact.
-    artifact_description : str
-        A brief description of the artifact.
-    filename : str
-        The path to the file to be uploaded as an artifact.
-    wandb_run : wandb.Run
-        The Weights & Biases run to log the artifact to.
+    nome_artefato : str
+        O nome do artefato.
+    tipo_artefato : str
+        O tipo do artefato.
+    descricao_artefato : str
+        Uma breve descrição do artefato.
+    nome_arquivo : str
+        O caminho para o arquivo a ser carregado como um artefato.
+    execucao_wandb : wandb.Run
+        A execução do Weights & Biases para registrar o artefato.
 
-    Returns
+    Retorna
     -------
-    None
+    Nada
     """
     
-    artifact = wandb.Artifact(
-        artifact_name,
-        type=artifact_type,
-        description=artifact_description,
+    artefato = wandb.Artifact(
+        nome_artefato,
+        type=tipo_artefato,
+        description=descricao_artefato,
     )
-    artifact.add_file(filename)
-    wandb_run.log_artifact(artifact)
-    #artifact.wait()
-    logger.info(f"Artifact {artifact_name} logged to W&B.")
+    artefato.add_file(nome_arquivo)
+    execucao_wandb.log_artifact(artefato)
+    #artefato.wait() # Mantido comentado, pois estava comentado no original
+    logger.info(f"Artefato {nome_artefato} registrado no W&B.")

--- a/components/get_data/wandb_utils/utils.py
+++ b/components/get_data/wandb_utils/utils.py
@@ -7,51 +7,133 @@ import wandb
 logging.basicConfig(level=logging.INFO, format="%(asctime)-15s %(message)s")
 logger = logging.getLogger(__name__)
 
-def download_file(url, output_path):
-    logger.info(f"Baixando arquivo de {url} para {output_path}")
-    response = requests.get(url)
-    response.raise_for_status()
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
-    with open(output_path, "wb") as f:
-        f.write(response.content)
-    logger.info("Download concluído.")
+def download_file(url, caminho_saida):
+    """
+    Baixa um arquivo de uma URL para um caminho de saída especificado.
 
-def extract_csv_from_zip(zip_path, extract_dir=None):
+    Parâmetros
+    ----------
+    url : str
+        A URL do arquivo a ser baixado.
+    caminho_saida : str
+        O caminho local onde o arquivo será salvo.
     """
-    Extrai arquivos CSV de um zip para o diretório especificado.
-    Se extract_dir não for informado, extrai para 'data/<nome_do_zip_sem_extensão>' no root do projeto.
-    """
-    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
-    data_root = os.path.join(project_root, 'data')
-    base_name = os.path.splitext(os.path.basename(zip_path))[0]
-    if extract_dir is None:
-        extract_dir = os.path.join(data_root, base_name)
-    logger.info(f"Extraindo arquivos CSV de {zip_path} para {extract_dir}")
-    os.makedirs(extract_dir, exist_ok=True)
-    csv_files = []
-    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
-        for file in zip_ref.namelist():
-            if file.endswith('.csv'):
-                zip_ref.extract(file, extract_dir)
-                csv_files.append(os.path.join(extract_dir, file))
-    if not csv_files:
-        logger.warning("Nenhum arquivo CSV encontrado no zip.")
-    else:
-        logger.info(f"Arquivos CSV extraídos: {csv_files}")
+    logger.info(f"Baixando arquivo de {url} para {caminho_saida}")
     try:
-        os.remove(zip_path)
-        logger.info(f"Arquivo zip deletado: {zip_path}")
-    except Exception as e:
-        logger.warning(f"Não foi possível deletar o arquivo zip: {e}")
-    return csv_files
+        resposta = requests.get(url)
+        resposta.raise_for_status()  # Levanta um erro para respostas HTTP ruins (4xx ou 5xx)
+        os.makedirs(os.path.dirname(caminho_saida), exist_ok=True)
+        with open(caminho_saida, "wb") as f:
+            f.write(resposta.content)
+        logger.info("Download concluído.")
+        return True # Retorna True em caso de sucesso
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Erro ao baixar o arquivo de {url}: {e}")
+        return False # Retorna False em caso de erro
 
-def artifact_exists(project, artifact_name):
+def extract_csv_from_zip(caminho_zip, diretorio_extracao=None, delete_zip_after_extraction=True):
+    """
+    Extrai arquivos CSV de um arquivo .zip para o diretório especificado.
+    Se diretorio_extracao não for informado, extrai para um subdiretório com o mesmo nome do arquivo .zip
+    (sem a extensão .zip) localizado no mesmo diretório do arquivo .zip.
+    Por exemplo, se caminho_zip é 'downloads/data.zip', o padrão para diretorio_extracao será 'downloads/data/'.
+
+    Parâmetros
+    ----------
+    caminho_zip : str
+        O caminho para o arquivo .zip.
+    diretorio_extracao : str, opcional
+        O diretório para onde os arquivos CSV serão extraídos. 
+        Se None, o padrão é um subdiretório nomeado após o arquivo zip no mesmo diretório do zip.
+    delete_zip_after_extraction : bool, opcional
+        Se True, deleta o arquivo zip após a extração. O padrão é True.
+
+    Retorna
+    -------
+    list
+        Uma lista dos caminhos dos arquivos CSV extraídos, ou uma lista vazia se nenhum arquivo .csv for encontrado ou em caso de erro.
+    """
+    if not os.path.exists(caminho_zip):
+        logger.error(f"Arquivo zip não encontrado em: {caminho_zip}")
+        return []
+
+    nome_base = os.path.splitext(os.path.basename(caminho_zip))[0]
+    
+    if diretorio_extracao is None:
+        # Default: subdirectory in the same directory as the zip file
+        diretorio_pai_zip = os.path.dirname(caminho_zip)
+        # Se caminho_zip for apenas o nome do arquivo (sem diretório), diretorio_pai_zip será ''
+        # os.path.join lidará com isso corretamente, criando o subdiretório no CWD.
+        diretorio_extracao = os.path.join(diretorio_pai_zip, nome_base)
+
+    logger.info(f"Extraindo arquivos CSV de '{caminho_zip}' para '{diretorio_extracao}'")
+    
+    try:
+        os.makedirs(diretorio_extracao, exist_ok=True)
+    except OSError as e:
+        logger.error(f"Erro ao criar o diretório de extração '{diretorio_extracao}': {e}")
+        return []
+
+    arquivos_csv = []
+    try:
+        with zipfile.ZipFile(caminho_zip, 'r') as ref_zip:
+            for arquivo in ref_zip.namelist():
+                if arquivo.endswith('.csv'):
+                    # Assegurar que arquivos dentro de pastas no zip sejam extraídos corretamente
+                    # e que o caminho final seja construído corretamente.
+                    # O método extract já lida com a estrutura de pastas internas.
+                    ref_zip.extract(arquivo, diretorio_extracao)
+                    # O caminho do arquivo extraído será relativo a diretorio_extracao
+                    caminho_completo_arquivo_extraido = os.path.join(diretorio_extracao, arquivo)
+                    arquivos_csv.append(caminho_completo_arquivo_extraido)
+        
+        if not arquivos_csv:
+            logger.warning(f"Nenhum arquivo .csv encontrado no arquivo zip: {caminho_zip}")
+        else:
+            logger.info(f"Arquivos CSV extraídos para '{diretorio_extracao}': {arquivos_csv}")
+
+    except zipfile.BadZipFile:
+        logger.error(f"Erro: O arquivo '{caminho_zip}' não é um arquivo zip válido ou está corrompido.")
+        return [] # Retorna lista vazia em caso de erro de zip
+    except Exception as e:
+        logger.error(f"Ocorreu um erro inesperado durante a extração do zip '{caminho_zip}': {e}")
+        return [] # Retorna lista vazia em caso de outros erros
+
+    if delete_zip_after_extraction:
+        try:
+            os.remove(caminho_zip)
+            logger.info(f"Arquivo zip '{caminho_zip}' deletado após extração.")
+        except Exception as e:
+            logger.warning(f"Não foi possível deletar o arquivo zip '{caminho_zip}' após extração: {e}")
+    else:
+        logger.info(f"Arquivo zip '{caminho_zip}' mantido após extração conforme solicitado (delete_zip_after_extraction=False).")
+        
+    return arquivos_csv
+
+def artifact_exists(projeto, nome_artefato):
+    """
+    Verifica se um artefato existe no W&B.
+
+    Parâmetros
+    ----------
+    projeto : str
+        O nome do projeto no W&B.
+    nome_artefato : str
+        O nome do artefato.
+
+    Retorna
+    -------
+    bool
+        True se o artefato existir, False caso contrário.
+    """
     api = wandb.Api()
     try:
-        s = api.artifact(f"{project}/{artifact_name}")
-        print (s)
+        artefato_status = api.artifact(f"{projeto}/{nome_artefato}")
+        logger.info(f"Artefato '{nome_artefato}' encontrado no projeto '{projeto}': {artefato_status}")
         return True
     except wandb.errors.CommError:
+        logger.info(f"Artefato '{nome_artefato}' não encontrado no projeto '{projeto}' devido a erro de comunicação.")
         return False
-    except wandb.errors.Error:
+    except wandb.errors.Error: # Captura genérica para outros erros do wandb
+        logger.info(f"Artefato '{nome_artefato}' não encontrado no projeto '{projeto}'.")
         return False


### PR DESCRIPTION
This commit addresses your general request to "revise o codigo" (revise the code).

Key changes include:

1.  **Language Standardization (Portuguese):**
    *   I translated comments, logging messages, print statements, and UI strings (like argparse help) to Portuguese in:
        *   `main.py`
        *   `components/get_data/run.py`
        *   `components/get_data/wandb_utils/log_artifact.py`
        *   `components/get_data/wandb_utils/utils.py`
    *   I also translated some variable and function parameter names to Portuguese where it improved clarity, while retaining common English terms/conventions (e.g., `args`, `parser`, `run`).

2.  **Error Handling and Robustness (`components/get_data/wandb_utils/utils.py`):**
    *   `download_file`: I added explicit `requests.exceptions.RequestException` handling and made the function return a boolean success status.
    *   `extract_csv_from_zip`:
        *   I made zip file deletion optional via a `delete_zip_after_extraction` parameter.
        *   I added checks for zip file existence, `BadZipFile` errors, and other exceptions during extraction.
    *   The calling script `components/get_data/run.py` was updated to check the return status of `download_file` and act accordingly.

3.  **File Path Logic (`components/get_data/wandb_utils/utils.py`):**
    *   I refactored `extract_csv_from_zip`'s default extraction directory logic to be simpler and based on the zip file's location, removing complex relative path calculations.

4.  **Configuration Enhancements:**
    *   While I encountered some issues directly modifying `config.yaml` (e.g., translating keys), I updated the Python scripts (`main.py` and `components/get_data/run.py`) to be more flexible:
        *   `main.py` now attempts to read potentially translated/new config keys with fallbacks to original names.
        *   The hardcoded "data" directory in `components/get_data/run.py` was parameterized and is now controllable via a `--local_data_dir` argument, which `main.py` can pass from a (future) configuration.

5.  **Dependency Correction (Critical Fix):**
    *   My review of `pyproject.toml` and `uv.lock` revealed critical issues:
        *   `pyproject.toml` specified non-existent future versions for many packages and a highly restrictive Python version (`>=3.13`).
        *   `uv.lock` was corrupted, locking these non-existent versions and showing future timestamps.
    *   My plan was to correct `pyproject.toml` versions to actual public releases, adjust the Python requirement, and then regenerate `uv.lock`.

**Work Remaining / Next Steps:**
The immediate next step was to execute the dependency correction and then regenerate `uv.lock`. After that, I planned to add a Portuguese `README.md`.

I wasn't stuck on the dependency correction itself; rather, this is the point in my plan where I've been asked to provide an update. The findings from the `pyproject.toml` and `uv.lock` review are significant, and fixing them is crucial for project reproducibility.